### PR TITLE
Cherry Pick launch optimisation commits from Texture 2.8

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -63,7 +63,6 @@
 #define ENABLE_NEW_EXIT_HIERARCHY_BEHAVIOR 0
 
 static ASDisplayNodeNonFatalErrorBlock _nonFatalErrorBlock = nil;
-NSInteger const ASDefaultDrawingPriority = ASDefaultTransactionPriority;
 
 // Forward declare CALayerDelegate protocol as the iOS 10 SDK moves CALayerDelegate from an informal delegate to a protocol.
 // We have to forward declare the protocol as this place otherwise it will not compile compiling with an Base SDK < iOS 10
@@ -272,7 +271,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   
 
   _contentsScaleForDisplay = ASScreenScale();
-  _drawingPriority = ASDefaultDrawingPriority;
+  _drawingPriority = ASDefaultTransactionPriority;
   
   _primitiveTraitCollection = ASPrimitiveTraitCollectionMakeDefault();
   

--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -36,7 +36,6 @@
 - (void)_locked_setDefaultImage:(UIImage *)image;
 @end
 
-NSString *const ASAnimatedImageDefaultRunLoopMode = NSRunLoopCommonModes;
 
 @implementation ASImageNode (AnimatedImage)
 

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -203,7 +203,14 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 }
 @dynamic placeholderEnabled;
 
-static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
+static NSArray *DefaultLinkAttributeNames() {
+  static NSArray *names;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    names = @[ NSLinkAttributeName ];
+  });
+  return names;
+}
 
 - (instancetype)init
 {
@@ -224,7 +231,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     self.opaque = NO;
     self.backgroundColor = [UIColor clearColor];
 
-    self.linkAttributeNames = DefaultLinkAttributeNames;
+    self.linkAttributeNames = DefaultLinkAttributeNames();
 
     // Accessibility
     self.isAccessibilityElement = YES;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -92,7 +92,14 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 }
 @dynamic placeholderEnabled;
 
-static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
+static NSArray *DefaultLinkAttributeNames() {
+  static NSArray *names;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    names = @[ NSLinkAttributeName ];
+  });
+  return names;
+}
 
 - (instancetype)init
 {
@@ -113,9 +120,9 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     // The common case is for a text node to be non-opaque and blended over some background.
     self.opaque = NO;
     self.backgroundColor = [UIColor clearColor];
-    
-    self.linkAttributeNames = DefaultLinkAttributeNames;
-    
+
+    self.linkAttributeNames = DefaultLinkAttributeNames();
+
     // Accessibility
     self.isAccessibilityElement = YES;
     self.accessibilityTraits = UIAccessibilityTraitStaticText;

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -183,14 +183,18 @@ static ASDN::StaticMutex& currentRequestsLock = *new ASDN::StaticMutex;
 @end
 
 @implementation NSURLRequest (ASBasicImageDownloader)
-static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext.class).UTF8String;
+
+static const void *ContextKey() {
+  return @selector(asyncdisplaykit_context);
+}
+
 - (void)setAsyncdisplaykit_context:(ASBasicImageDownloaderContext *)asyncdisplaykit_context
 {
-  objc_setAssociatedObject(self, kContextKey, asyncdisplaykit_context, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  objc_setAssociatedObject(self, ContextKey(), asyncdisplaykit_context, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 - (ASBasicImageDownloader *)asyncdisplaykit_context
 {
-  return objc_getAssociatedObject(self, kContextKey);
+  return objc_getAssociatedObject(self, ContextKey());
 }
 @end
 

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -17,7 +17,7 @@
 
 #import <AsyncDisplayKit/ASThread.h>
 
-extern NSString *const ASAnimatedImageDefaultRunLoopMode;
+#define ASAnimatedImageDefaultRunLoopMode NSRunLoopCommonModes
 
 @interface ASImageNode ()
 {

--- a/Source/Private/_ASCoreAnimationExtras.mm
+++ b/Source/Private/_ASCoreAnimationExtras.mm
@@ -65,42 +65,58 @@ struct _UIContentModeStringLUTEntry {
   NSString *const string;
 };
 
-static const struct _UIContentModeStringLUTEntry UIContentModeCAGravityLUT[] = {
-  {UIViewContentModeScaleToFill,     kCAGravityResize},
-  {UIViewContentModeScaleAspectFit,  kCAGravityResizeAspect},
-  {UIViewContentModeScaleAspectFill, kCAGravityResizeAspectFill},
-  {UIViewContentModeCenter,          kCAGravityCenter},
-  {UIViewContentModeTop,             kCAGravityBottom},
-  {UIViewContentModeBottom,          kCAGravityTop},
-  {UIViewContentModeLeft,            kCAGravityLeft},
-  {UIViewContentModeRight,           kCAGravityRight},
-  {UIViewContentModeTopLeft,         kCAGravityBottomLeft},
-  {UIViewContentModeTopRight,        kCAGravityBottomRight},
-  {UIViewContentModeBottomLeft,      kCAGravityTopLeft},
-  {UIViewContentModeBottomRight,     kCAGravityTopRight},
-};
+static const _UIContentModeStringLUTEntry *UIContentModeCAGravityLUT(size_t *count)
+{
+  // Initialize this in a function (instead of at file level) to avoid
+  // startup initialization time.
+  static const _UIContentModeStringLUTEntry sUIContentModeCAGravityLUT[] = {
+    {UIViewContentModeScaleToFill,     kCAGravityResize},
+    {UIViewContentModeScaleAspectFit,  kCAGravityResizeAspect},
+    {UIViewContentModeScaleAspectFill, kCAGravityResizeAspectFill},
+    {UIViewContentModeCenter,          kCAGravityCenter},
+    {UIViewContentModeTop,             kCAGravityBottom},
+    {UIViewContentModeBottom,          kCAGravityTop},
+    {UIViewContentModeLeft,            kCAGravityLeft},
+    {UIViewContentModeRight,           kCAGravityRight},
+    {UIViewContentModeTopLeft,         kCAGravityBottomLeft},
+    {UIViewContentModeTopRight,        kCAGravityBottomRight},
+    {UIViewContentModeBottomLeft,      kCAGravityTopLeft},
+    {UIViewContentModeBottomRight,     kCAGravityTopRight},
+  };
+  *count = sizeof(sUIContentModeCAGravityLUT) / sizeof(sUIContentModeCAGravityLUT[0]);
+  return sUIContentModeCAGravityLUT;
+}
 
-static const struct _UIContentModeStringLUTEntry UIContentModeDescriptionLUT[] = {
-  {UIViewContentModeScaleToFill,     @"scaleToFill"},
-  {UIViewContentModeScaleAspectFit,  @"aspectFit"},
-  {UIViewContentModeScaleAspectFill, @"aspectFill"},
-  {UIViewContentModeRedraw,          @"redraw"},
-  {UIViewContentModeCenter,          @"center"},
-  {UIViewContentModeTop,             @"top"},
-  {UIViewContentModeBottom,          @"bottom"},
-  {UIViewContentModeLeft,            @"left"},
-  {UIViewContentModeRight,           @"right"},
-  {UIViewContentModeTopLeft,         @"topLeft"},
-  {UIViewContentModeTopRight,        @"topRight"},
-  {UIViewContentModeBottomLeft,      @"bottomLeft"},
-  {UIViewContentModeBottomRight,     @"bottomRight"},
-};
+static const _UIContentModeStringLUTEntry *UIContentModeDescriptionLUT(size_t *count)
+{
+  // Initialize this in a function (instead of at file level) to avoid
+  // startup initialization time.
+  static const _UIContentModeStringLUTEntry sUIContentModeDescriptionLUT[] = {
+    {UIViewContentModeScaleToFill,     @"scaleToFill"},
+    {UIViewContentModeScaleAspectFit,  @"aspectFit"},
+    {UIViewContentModeScaleAspectFill, @"aspectFill"},
+    {UIViewContentModeRedraw,          @"redraw"},
+    {UIViewContentModeCenter,          @"center"},
+    {UIViewContentModeTop,             @"top"},
+    {UIViewContentModeBottom,          @"bottom"},
+    {UIViewContentModeLeft,            @"left"},
+    {UIViewContentModeRight,           @"right"},
+    {UIViewContentModeTopLeft,         @"topLeft"},
+    {UIViewContentModeTopRight,        @"topRight"},
+    {UIViewContentModeBottomLeft,      @"bottomLeft"},
+    {UIViewContentModeBottomRight,     @"bottomRight"},
+  };
+  *count = sizeof(sUIContentModeDescriptionLUT) / sizeof(sUIContentModeDescriptionLUT[0]);
+  return sUIContentModeDescriptionLUT;
+}
 
 NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (int i=0; i< ARRAY_COUNT(UIContentModeDescriptionLUT); i++) {
-    if (UIContentModeDescriptionLUT[i].contentMode == contentMode) {
-      return UIContentModeDescriptionLUT[i].string;
+  size_t lutSize;
+  const _UIContentModeStringLUTEntry *lut = UIContentModeDescriptionLUT(&lutSize);
+  for (size_t i = 0; i < lutSize; ++i) {
+    if (lut[i].contentMode == contentMode) {
+      return lut[i].string;
     }
   }
   return [NSString stringWithFormat:@"%d", (int)contentMode];
@@ -108,9 +124,11 @@ NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 
 UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 {
-  for (int i=0; i < ARRAY_COUNT(UIContentModeDescriptionLUT); i++) {
-    if (ASObjectIsEqual(UIContentModeDescriptionLUT[i].string, string)) {
-      return UIContentModeDescriptionLUT[i].contentMode;
+  size_t lutSize;
+  const _UIContentModeStringLUTEntry *lut = UIContentModeDescriptionLUT(&lutSize);
+  for (size_t i = 0; i < lutSize; ++i) {
+    if (ASObjectIsEqual(lut[i].string, string)) {
+      return lut[i].contentMode;
     }
   }
   return UIViewContentModeScaleToFill;
@@ -118,9 +136,11 @@ UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 
 NSString *const ASDisplayNodeCAContentsGravityFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (int i=0; i < ARRAY_COUNT(UIContentModeCAGravityLUT); i++) {
-    if (UIContentModeCAGravityLUT[i].contentMode == contentMode) {
-      return UIContentModeCAGravityLUT[i].string;
+  size_t lutSize;
+  const _UIContentModeStringLUTEntry *lut = UIContentModeCAGravityLUT(&lutSize);
+  for (size_t i = 0; i < lutSize; ++i) {
+    if (lut[i].contentMode == contentMode) {
+      return lut[i].string;
     }
   }
   ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %zd. Is this a new version of iOS?", contentMode);
@@ -140,9 +160,11 @@ UIViewContentMode ASDisplayNodeUIContentModeFromCAContentsGravity(NSString *cons
     return cachedModes[foundCacheIndex];
   }
   
-  for (int i = 0; i < ARRAY_COUNT(UIContentModeCAGravityLUT); i++) {
-    if (ASObjectIsEqual(UIContentModeCAGravityLUT[i].string, contentsGravity)) {
-      UIViewContentMode foundContentMode = UIContentModeCAGravityLUT[i].contentMode;
+    size_t lutSize;
+    const _UIContentModeStringLUTEntry *lut = UIContentModeCAGravityLUT(&lutSize);
+    for (size_t i = 0; i < lutSize; ++i) {
+    if (ASObjectIsEqual(lut[i].string, contentsGravity)) {
+      UIViewContentMode foundContentMode = lut[i].contentMode;
       
       if (currentCacheIndex < ContentModeCacheSize) {
         // Cache the input value.  This is almost always a different pointer than in our LUT and will frequently


### PR DESCRIPTION
Cherry picked the app launch time reduction commits from Texture-2.8.

Following is the list of all the merged PRs

1. [Make global static a function local static. This stops it from being initialized premain and affecting startup time.](https://github.com/TextureGroup/Texture/pull/1288)
2. [Get rid of file scope initialization that causes a premain startup hit.](https://github.com/TextureGroup/Texture/pull/1291)
3. [Move file scope constant that is initialized at startup to function scope to avoid startup hit.](https://github.com/TextureGroup/Texture/pull/1292)
4. [Move file level static into a function so that it isn't being initialized pre-main.](https://github.com/TextureGroup/Texture/pull/1293)
5. [Initializing the LUT arrays at file level scope creates a large chunk of code retaining and releasing all of the NSStrings in the tables. Moving them to function level moves the initialization to being lazy.](https://github.com/TextureGroup/Texture/pull/1294)

