### PR TITLE
ASDataController Disable Flushing Experiment 

### DIFF
--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -549,6 +549,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
 
+#pragma mark - Experiments
+
+/**
+ * Enable flush editing in DataController
+ * Flush editing will be removed in further version, in version 2.8 the flush editing toggled by ASExperiments.
+ * Since using ASExperiments will enable the whole Texture Code, This property allows to configure individually
+ *
+ * The default value is YES.
+*/
+@property (nonatomic) BOOL enableFlushEditing;
+
+@end
+
 @end
 
 @interface ASCollectionNode (Deprecated)

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -562,8 +562,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@end
-
 @interface ASCollectionNode (Deprecated)
 
 - (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("This method has been renamed to -waitUntilAllUpdatesAreProcessed.");

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -56,6 +56,7 @@
 @property (nonatomic) BOOL animatesContentOffset;
 @property (nonatomic) BOOL showsVerticalScrollIndicator;
 @property (nonatomic) BOOL showsHorizontalScrollIndicator;
+@property (nonatomic) BOOL enableFlushEditing;
 @end
 
 @implementation _ASCollectionPendingState
@@ -71,6 +72,7 @@
     _contentInset = UIEdgeInsetsZero;
     _contentOffset = CGPointZero;
     _animatesContentOffset = NO;
+    _enableFlushEditing = NO;
   }
   return self;
 }
@@ -229,6 +231,8 @@
     if (pendingState.rangeMode != ASLayoutRangeModeUnspecified) {
       [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];
     }
+    
+    view.dataController.enableFlushEditing = pendingState.enableFlushEditing;
     
     // Don't need to set collectionViewLayout to the view as the layout was already used to init the view in view block.
   }
@@ -1002,6 +1006,22 @@
   if (self.nodeLoaded) {
     [self.view moveItemAtIndexPath:indexPath toIndexPath:newIndexPath];
   }
+}
+
+#pragma mark - Experiments
+
+-(void)setEnableFlushEditing:(BOOL)enableFlushEditing
+{
+  if ([self pendingState]) {
+    _pendingState.enableFlushEditing = enableFlushEditing;
+  } else {
+    [self.dataController setEnableFlushEditing:enableFlushEditing];
+  }
+}
+
+-(BOOL)enableFlushEditing
+{
+  return self.dataController.enableFlushEditing;
 }
 
 #pragma mark - ASRangeControllerUpdateRangeProtocol

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -72,7 +72,7 @@
     _contentInset = UIEdgeInsetsZero;
     _contentOffset = CGPointZero;
     _animatesContentOffset = NO;
-    _enableFlushEditing = NO;
+    _enableFlushEditing = YES;
   }
   return self;
 }

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -482,6 +482,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<NSIndexPath *> *)indexPathsForVisibleRows AS_WARN_UNUSED_RESULT;
 
+#pragma mark - Experiments
+
+/**
+ * Enable flush editing in DataController
+ * Flush editing will be removed in further version, in version 2.8 the flush editing toggled by ASExperiments.
+ * Since using ASExperiments will enable the whole Texture Code, This property allows to configure individually
+ *
+ * The default value is YES.
+*/
+@property (nonatomic) BOOL enableFlushEditing;
+
 @end
 
 /**

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -47,6 +47,7 @@
 @property (nonatomic) CGPoint contentOffset;
 @property (nonatomic) BOOL animatesContentOffset;
 @property (nonatomic) BOOL automaticallyAdjustsContentOffset;
+@property (nonatomic) BOOL enableFlushEditing;
 @end
 
 @implementation _ASTablePendingState
@@ -65,6 +66,7 @@
     _contentOffset = CGPointZero;
     _animatesContentOffset = NO;
     _automaticallyAdjustsContentOffset = NO;
+    _enableFlushEditing = YES;
   }
   return self;
 }
@@ -142,6 +144,8 @@
     }
 
     [view setContentOffset:pendingState.contentOffset animated:pendingState.animatesContentOffset];
+    
+    view.dataController.enableFlushEditing = pendingState.enableFlushEditing;
   }
 }
 
@@ -809,6 +813,22 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
   [result addObject:@{ @"dataSource" : ASObjectDescriptionMakeTiny(self.dataSource) }];
   [result addObject:@{ @"delegate" : ASObjectDescriptionMakeTiny(self.delegate) }];
   return result;
+}
+
+#pragma mark - Experiments
+
+-(void)setEnableFlushEditing:(BOOL)enableFlushEditing
+{
+  if ([self pendingState]) {
+    _pendingState.enableFlushEditing = enableFlushEditing;
+  } else {
+    [self.dataController setEnableFlushEditing:enableFlushEditing];
+  }
+}
+
+-(BOOL)enableFlushEditing
+{
+  return self.dataController.enableFlushEditing;
 }
 
 @end

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -285,6 +285,18 @@ extern NSString * const ASCollectionInvalidUpdateException;
  */
 - (void)clearData;
 
+#pragma mark - Experiments
+
+/**
+ * Enable flush editing in DataController
+ * Flush editing will be removed in further version, in version 2.8 the flush editing toggled by ASExperiments.
+ * Since using ASExperiments will enable the whole Texture Code, This property allows to configure individually
+ *
+ * The default value is YES.
+*/
+@property (nonatomic) BOOL enableFlushEditing;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -75,6 +75,8 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   BOOL _initialReloadDataHasBeenCalled;
 
   BOOL _synchronized;
+  BOOL _enableFlushEditing;
+  
   NSMutableSet<ASDataControllerSynchronizationBlock> *_onDidFinishSynchronizingBlocks;
 
   struct {
@@ -201,6 +203,18 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   CGRect frame = CGRectZero;
   frame.size = [node layoutThatFits:constrainedSize].size;
   node.frame = frame;
+}
+
+#pragma mark - Experiments
+
+-(void)setEnableFlushEditing:(BOOL)enableFlushEditing
+{
+  _enableFlushEditing = enableFlushEditing;
+}
+
+-(BOOL)enableFlushEditing
+{
+  return _enableFlushEditing;
 }
 
 #pragma mark - Data Source Access (Calling _dataSource)

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -535,12 +535,15 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     as_log_debug(ASCollectionLog(), "performBatchUpdates %@ %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)), changeSet);
   }
   
-  NSTimeInterval transactionQueueFlushDuration = 0.0f;
-  {
-    ASDN::ScopeTimer t(transactionQueueFlushDuration);
-    dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
+  if (_enableFlushEditing) {
+    NSTimeInterval transactionQueueFlushDuration = 0.0f;
+     {
+       ASDN::ScopeTimer t(transactionQueueFlushDuration);
+       dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
+     }
+     
   }
-  
+ 
   // If the initial reloadData has not been called, just bail because we don't have our old data source counts.
   // See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
   // for the issue that UICollectionView has that we're choosing to workaround.

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -124,6 +124,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   _mainSerialQueue = [[ASMainSerialQueue alloc] init];
 
   _synchronized = YES;
+  _enableFlushEditing = YES;
   _onDidFinishSynchronizingBlocks = [NSMutableSet set];
   
   const char *queueName = [[NSString stringWithFormat:@"org.AsyncDisplayKit.ASDataController.editingTransactionQueue:%p", self] cStringUsingEncoding:NSASCIIStringEncoding];


### PR DESCRIPTION
In Texture 2.8 the code that makes the collection / table deadlock will be be removed,
```
NSTimeInterval transactionQueueFlushDuration = 0.0f;
     {
       ASDN::ScopeTimer t(transactionQueueFlushDuration);
       dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
     }
```
PR Texture: TextureGroup/Texture#1564

But the Texture team creates a flag experiment before completely remove the code and impact to all collection / table. For safety we follow the approach in Texture 2.8 by creating our flag, so we can configure it manually for each collection/table